### PR TITLE
Update build system for linux; fix window declaration for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 build/
 CMakeUserPresets.json
 .DS_Store
+
+# Direnv files from linux, currently specific to NixOS so ignoring for now
+.direnv
+.envrc

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,37 +1,63 @@
 {
-  "version": 3,
-  "configurePresets": [
-    {
-      "name": "ninja-vcpkg-release",
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/release",
-      "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": "x64-windows",
-        "VCPKG_FEATURE_FLAGS": "manifests",
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "name": "ninja-vcpkg-debug",
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/debug",
-      "cacheVariables": {
-        "VCPKG_TARGET_TRIPLET": "x64-windows",
-        "VCPKG_FEATURE_FLAGS": "manifests",
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    }
-  ],
-  "buildPresets": [
-    {
-      "name": "build-release",
-      "configurePreset": "ninja-vcpkg-release",
-      "description": "Builds project in release mode"
-    },
-    {
-      "name": "build-debug",
-      "configurePreset": "ninja-vcpkg-debug",
-      "description": "Builds project in debug mode"
-    }
-  ]
+	"version": 3,
+	"configurePresets": [
+		{
+			"name": "ninja-vcpkg-release",
+			"generator": "Ninja",
+			"binaryDir": "${sourceDir}/build/windows-release",
+			"cacheVariables": {
+				"VCPKG_TARGET_TRIPLET": "x64-windows",
+				"VCPKG_FEATURE_FLAGS": "manifests",
+				"CMAKE_BUILD_TYPE": "Release"
+			}
+		},
+		{
+			"name": "ninja-vcpkg-debug",
+			"generator": "Ninja",
+			"binaryDir": "${sourceDir}/build/windows-debug",
+			"cacheVariables": {
+				"VCPKG_TARGET_TRIPLET": "x64-windows",
+				"VCPKG_FEATURE_FLAGS": "manifests",
+				"CMAKE_BUILD_TYPE": "Debug"
+			}
+		},
+		{
+			"name": "linux-release",
+			"generator": "Ninja",
+			"binaryDir": "${sourceDir}/build/linux-release",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Release"
+			}
+		},
+		{
+			"name": "linux-debug",
+			"generator": "Ninja",
+			"binaryDir": "${sourceDir}/build/linux-debug",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Debug"
+			}
+		}
+	],
+	"buildPresets": [
+		{
+			"name": "build-release",
+			"configurePreset": "ninja-vcpkg-release",
+			"description": "Builds project in release mode"
+		},
+		{
+			"name": "build-debug",
+			"configurePreset": "ninja-vcpkg-debug",
+			"description": "Builds project in debug mode"
+		},
+		{
+			"name": "linux-release",
+			"configurePreset": "linux-release",
+			"description": "Build project in release mode, for Linux"
+		},
+		{
+			"name": "linux-debug",
+			"configurePreset": "linux-debug",
+			"description": "Builds project in debug mode, for Linux"
+		}
+	]
 }

--- a/NixModules/opencascade.nix
+++ b/NixModules/opencascade.nix
@@ -20,9 +20,6 @@
 	libXi,
 	vtk,
 	withVtk ? false,
-
-	# used in passthru.tests
-	opencascade-occt,
 }:
 stdenv.mkDerivation rec {
 	pname = "opencascade-occt";
@@ -79,12 +76,6 @@ stdenv.mkDerivation rec {
 		(lib.cmakeBool "USE_VTK" true)
 		(lib.cmakeFeature "3RDPARTY_VTK_INCLUDE_DIR" "${lib.getDev vtk}/include/vtk")
 	];
-
-	passthru = {
-	tests = {
-	withVtk = opencascade-occt.override { withVtk = true; };
-	};
-	};
 
 	meta = {
 		description = "Open CASCADE Technology, libraries for 3D modeling and numerical simulation";

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1769789167,
+        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
         "owner": "Nixos",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
         "type": "github"
       },
       "original": {

--- a/src/render/OcctViewport.cpp
+++ b/src/render/OcctViewport.cpp
@@ -35,7 +35,7 @@ void OcctViewport::initialize(WId windowHandle)
 #ifdef Q_OS_WIN
     Handle(WNT_Window) wind = new WNT_Window((Aspect_Handle)windowHandle);
 #elif defined(Q_OS_LINUX)
-    Handle(Xw_Window) wind = new Xw_Window(displayConnection, (Aspect_Handle)windowHandle);
+    Handle(Xw_Window) wind = new Xw_Window(displayConnection, (Aspect_Drawable)windowHandle);
 #elif defined(Q_OS_MAC)
     Handle(Cocoa_Window) wind = new Cocoa_Window((NSView *)windowHandle);
 #endif


### PR DESCRIPTION
Build system should work with Nix package manager. For other package manager, install dependencies regularly and run cmake as usual.

Features:
- Added 2 new presets for build in linux (debug & release). Both are currently basic ninja cmake build, so should be usable in other OS.
- Fix OCCT window declaration in linux