### PR TITLE
Change cmakelists to add macOS support for OCCT/VTK rendering.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,6 @@ if(APPLE)
     )
 
     target_link_libraries(${PROJECT_NAME} PRIVATE "-framework AppKit" "-framework OpenGL")
-    add_link_options("-Wl,-no_pie")
-    add_compile_options("-mcmodel=large")
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,14 @@ set(CMAKE_AUTORCC ON)
 # 2. Find Packages
 find_package(Qt6 REQUIRED COMPONENTS Widgets OpenGLWidgets)
 find_package(OpenCASCADE REQUIRED)
-find_package(VTK REQUIRED)
+find_package(VTK REQUIRED COMPONENTS
+    CommonCore
+    CommonDataModel
+    FiltersSources
+    RenderingCore
+    RenderingOpenGL2
+    GUISupportQt
+)
 
 # 3. Define the Executable (Qt6 Style)
 # MANUAL_FINALIZATION is recommended for complex projects to handle deployment/plugins
@@ -39,7 +46,11 @@ target_include_directories(${PROJECT_NAME} PRIVATE src)
 # 5. Platform Specifics
 if(APPLE)
     # Objective-C++ support for Cocoa window handles
-    set_source_files_properties(src/main.cpp PROPERTIES COMPILE_FLAGS "-x objective-c++")
+    set_source_files_properties(
+        src/main.cpp
+        src/render/OcctViewport.cpp
+        PROPERTIES COMPILE_FLAGS "-x objective-c++"
+    )
     
     set_target_properties(${PROJECT_NAME} PROPERTIES
         MACOSX_BUNDLE TRUE
@@ -49,6 +60,8 @@ if(APPLE)
     )
 
     target_link_libraries(${PROJECT_NAME} PRIVATE "-framework AppKit" "-framework OpenGL")
+    add_link_options("-Wl,-no_pie")
+    add_compile_options("-mcmodel=large")
 endif()
 
 if(WIN32)
@@ -65,8 +78,13 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     TKernel TKMath TKG2d TKG3d TKGeomBase
     TKBRep TKTopAlgo TKPrim TKService TKV3d TKOpenGl
     
-    # VTK Libraries
-    ${VTK_LIBRARIES}
+    # VTK Libraries (explicit list avoids over-linking/auto-init issues)
+    VTK::CommonCore
+    VTK::CommonDataModel
+    VTK::FiltersSources
+    VTK::RenderingCore
+    VTK::RenderingOpenGL2
+    VTK::GUISupportQt
 )
 
 # 7. Include Paths
@@ -76,7 +94,16 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 )
 
 # 8. VTK Initialization
-vtk_module_autoinit(TARGETS ${PROJECT_NAME} MODULES ${VTK_LIBRARIES})
+vtk_module_autoinit(
+    TARGETS ${PROJECT_NAME}
+    MODULES
+        VTK::CommonCore
+        VTK::CommonDataModel
+        VTK::FiltersSources
+        VTK::RenderingCore
+        VTK::RenderingOpenGL2
+        VTK::GUISupportQt
+)
 
 # 9. Windows Deployment (Post-Build)
 if(WIN32)


### PR DESCRIPTION
Introduces macOS support by enabling Objective-C++ compilation where needed for proper Cocoa window integration, switching to explicit VTK module linkage with matching vtk_module_autoinit to ensure stable and predictable initialization, and linking the required macOS system frameworks cleanly to support OCCT and OpenGL.